### PR TITLE
fix misspelling of Nightingale

### DIFF
--- a/src/docs/components/DonutChart.js
+++ b/src/docs/components/DonutChart.js
@@ -24,7 +24,7 @@ export default class PieDonutDocs extends React.Component {
   render() {
     const examples = [];
 
-    const kindOptions = ["pie", "nightengale"].map(d => (
+    const kindOptions = ["pie", "nightingale"].map(d => (
       <MenuItem key={"kind-option" + d} label={d} value={d}>
         {d}
       </MenuItem>

--- a/src/docs/example_settings/example_list.js
+++ b/src/docs/example_settings/example_list.js
@@ -36,7 +36,7 @@ const exampos = [
     path: "regionatedlinechart"
   },
   {
-    label: "Pie/Donut/Nightengale",
+    label: "Pie/Donut/Nightingale",
     viz: DonutChartRaw({ kind: "pie" }),
     path: "donutchart"
   },


### PR DESCRIPTION
In two places, "Nightingale" was spelled "Nightengale".