### PR TITLE
Possible bugfix for custom networkType function 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "semiotic",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semiotic",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "The semiotic JavaScript data visualization framework",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
Before the change, it seems that if we supply a custom networkType function, this function won't be used as it is evaluated outside the 'dataChanged / networkSettingsChanged' if clause. If I understood the intention correctly, this should be part of that clause for users who want full control of nodes & links generations.