### PR TITLE
fix: don't access uninitialized canvas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,16 @@
       "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ==",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -3828,8 +3838,8 @@
       "integrity": "sha512-8od6g684Fhi5Vpp4ABRv/RBsW1AY6wSHbJHEK6FGTv+8jvAAnlABniZu/FVmX9TcirkHepaEsa1QGkRvbg0CKw==",
       "dev": true,
       "requires": {
-        "is-text-path": "1.0.1",
         "JSONStream": "1.3.1",
+        "is-text-path": "1.0.1",
         "lodash": "4.17.4",
         "meow": "3.7.0",
         "split2": "2.2.0",
@@ -3858,8 +3868,8 @@
           "integrity": "sha1-4ye1MZThp61dxjR57pCZpSsCSGU=",
           "dev": true,
           "requires": {
-            "is-text-path": "1.0.1",
             "JSONStream": "1.3.1",
+            "is-text-path": "1.0.1",
             "lodash": "4.17.4",
             "meow": "3.7.0",
             "split2": "2.2.0",
@@ -6940,15 +6950,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -6958,6 +6959,15 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -9337,16 +9347,6 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
-    },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -13157,12 +13157,13 @@
       }
     },
     "react-annotation": {
-      "version": "0.0.1-3",
-      "resolved": "https://registry.npmjs.org/react-annotation/-/react-annotation-0.0.1-3.tgz",
-      "integrity": "sha512-nHf5lSJbt44oO++HkbDKzzZNpJSchrJ9zjSmJJcio4kNztfXj+//skfqoqwOKhGCKOtvCaAlsy7LJtcE/6uGUg==",
+      "version": "0.0.1-4",
+      "resolved": "https://registry.npmjs.org/react-annotation/-/react-annotation-0.0.1-4.tgz",
+      "integrity": "sha512-Ch30w5L3RyaLLpsJpFviBJvDmTLnf1CXBVejN7/1NayhmBpm2wXCF7gBCpooI7kSTcQ9n2k79Ra+sDJHupPsUA==",
       "requires": {
         "classnames": "2.2.5",
         "d3-shape": "1.0.4",
+        "prop-types": "15.6.0",
         "react-draggable": "3.0.3"
       },
       "dependencies": {
@@ -14889,15 +14890,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -14943,6 +14935,15 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.9.0",
         "function-bind": "1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringify-object": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "lint": "eslint src",
+    "lint": "eslint src/components",
     "prebuild": "babel src/components --out-dir lib --ignore test.js",
     "create-release-branch": "sh ./scripts/create-release-branch",
     "publish-release": "sh ./scripts/publish-release",
@@ -21,9 +21,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/emeeks/semiotic.git"
-  },
-  "config": {
-    "is-component": "y"
   },
   "author": {
     "name": "Elijah Meeks",

--- a/src/components/ResponsiveFrame.js
+++ b/src/components/ResponsiveFrame.js
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactResizeDetector from "react-resize-detector";
+import PropTypes from "prop-types";
 import XYFrame from "./XYFrame";
 import ORFrame from "./ORFrame";
 import NetworkFrame from "./NetworkFrame";
@@ -8,14 +9,20 @@ import MinimapXYFrame from "./MinimapXYFrame";
 
 const createResponsiveFrame = Frame =>
   class ResponsiveFrame extends React.Component {
+    static propTypes = {
+      size : PropTypes.array
+    };
+
+    static defaultProps = {
+      size : [500, 500]
+    };
+    
     constructor(props) {
       super(props);
 
-      this._onResize = this._onResize.bind(this);
-
       this.state = {
-        containerHeight: props.size[1] || 500,
-        containerWidth: props.size[0] || 500
+        containerHeight: props.size[1],
+        containerWidth: props.size[0]
       };
 
       this.oAccessor = null;
@@ -24,7 +31,7 @@ const createResponsiveFrame = Frame =>
       this.rScale = null;
     }
 
-    _onResize(width, height) {
+    _onResize = (width, height) => {
       this.setState({ containerHeight: height, containerWidth: width });
     }
 
@@ -32,7 +39,7 @@ const createResponsiveFrame = Frame =>
       const {
         responsiveWidth,
         responsiveHeight,
-        size = [500, 500],
+        size,
         dataVersion
       } = this.props;
 
@@ -46,7 +53,7 @@ const createResponsiveFrame = Frame =>
         size[1] = containerHeight;
       }
 
-      let dataVersionWithSize = dataVersion + size.toString();
+      const dataVersionWithSize = dataVersion + size.toString();
 
       return (
         <div className="responsive-container">

--- a/src/components/ResponsiveFrame.test.js
+++ b/src/components/ResponsiveFrame.test.js
@@ -1,0 +1,39 @@
+import React from "react"
+import { mount, shallow } from "enzyme"
+import * as ResponsiveFrameComponents from "./ResponsiveFrame"
+import injectTapEventPlugin from "react-tap-event-plugin"
+injectTapEventPlugin()
+
+/* 
+export const ResponsiveXYFrame = createResponsiveFrame(XYFrame);
+export const ResponsiveORFrame = createResponsiveFrame(ORFrame);
+export const ResponsiveNetworkFrame = createResponsiveFrame(NetworkFrame);
+export const ResponsiveSmartFrame = createResponsiveFrame(SmartFrame);
+export const ResponsiveMinimapXYFrame = createResponsiveFrame(MinimapXYFrame);
+*/
+
+describe("ResponsiveFrameComponents", () => {
+  Object.keys(ResponsiveFrameComponents).forEach(componentName => {
+    const ResponsiveFrameComponent = ResponsiveFrameComponents[componentName]
+
+    it("renders", () => {
+      mount(<ResponsiveFrameComponent 
+        dataVersion={"foo"} 
+        disableContext={true}
+        responsiveHeight={true}
+        responsiveWidth={true} />)
+    })
+  
+    it("renders a <ResizeDetector />", () => {
+      const wrapper = shallow(
+        <ResponsiveFrameComponent 
+          dataVersion={"foo"} 
+          disableContext={true}
+          responsiveHeight={true}
+          responsiveWidth={true} />
+      )
+
+      expect(wrapper.find("ResizeDetector").length).toEqual(1)
+    })
+  })
+})

--- a/src/components/VisualizationLayer.js
+++ b/src/components/VisualizationLayer.js
@@ -9,70 +9,66 @@ import { hexToRgb } from "./svg/SvgHelper";
 import PropTypes from "prop-types";
 
 class VisualizationLayer extends React.PureComponent {
-  constructor(props) {
-    super(props);
+  static defaultProps = { position : [0, 0] };
 
-    this.canvasDrawing = [];
+  canvasDrawing = [ ];
 
-    this.state = {
-      canvasDrawing: [],
-      dataVersion: "",
-      renderedElements: []
-    };
-  }
+  state = {
+    canvasDrawing: [],
+    dataVersion: "",
+    renderedElements: []
+  };
 
   componentDidUpdate() {
-    const adjustedPosition = this.props.position || [0, 0];
-    let context;
-    if (this.props.canvasContext && !this.props.disableContext) {
-      context = this.props.canvasContext.getContext("2d");
+    if (this.props.disableContext || !this.props.canvasContext || !this.canvasDrawing.length)
+      return;
+    
+    const context = this.props.canvasContext.getContext("2d");
+    context.setTransform(1, 0, 0, 1, 0, 0);
+    context.clearRect(0, 0, this.props.size[0] * 2, this.props.size[1] * 2);
+
+    this.canvasDrawing.forEach(piece => {
+      const style = piece.styleFn ? piece.styleFn(piece.d, piece.i) : "black";
+      let fill = style.fill ? style.fill : "black";
+      let stroke = style.stroke ? style.stroke : "black";
+      fill = !style.fillOpacity
+        ? fill
+        : `rgba(${[...hexToRgb(fill), style.fillOpacity]})`;
+      stroke = !style.strokeOpacity
+        ? stroke
+        : `rgba(${[...hexToRgb(stroke), style.strokeOpacity]})`;
       context.setTransform(1, 0, 0, 1, 0, 0);
-      context.clearRect(0, 0, this.props.size[0] * 2, this.props.size[1] * 2);
-    }
-    if (this.props.canvasContext && this.canvasDrawing.length > 0) {
-      this.canvasDrawing.forEach(piece => {
-        const style = piece.styleFn ? piece.styleFn(piece.d, piece.i) : "black";
-        let fill = style.fill ? style.fill : "black";
-        let stroke = style.stroke ? style.stroke : "black";
-        fill = !style.fillOpacity
-          ? fill
-          : "rgba(" + [...hexToRgb(fill), style.fillOpacity] + ")";
-        stroke = !style.strokeOpacity
-          ? stroke
-          : "rgba(" + [...hexToRgb(stroke), style.strokeOpacity] + ")";
-        context.setTransform(1, 0, 0, 1, 0, 0);
-        context.translate(...adjustedPosition);
-        context.translate(piece.tx, piece.ty);
-        context.fillStyle = fill;
-        context.strokeStyle = stroke;
-        context.lineWidth = style.strokeWidth ? style.strokeWidth : "black";
-        if (piece.markProps.markType === "circle") {
-          context.beginPath();
-          context.arc(0, 0, piece.markProps.r, 0, 2 * Math.PI);
-          context.stroke();
-          context.fill();
-        } else if (piece.markProps.markType === "rect") {
-          context.fillRect(
-            piece.markProps.x,
-            piece.markProps.y,
-            piece.markProps.width,
-            piece.markProps.height
-          );
-          context.strokeRect(
-            piece.markProps.x,
-            piece.markProps.y,
-            piece.markProps.width,
-            piece.markProps.height
-          );
-        } else if (piece.markProps.markType === "path") {
-          const p = new Path2D(piece.markProps.d);
-          context.stroke(p);
-          context.fill(p);
-        } else {
-          console.error("CURRENTLY UNSUPPORTED MARKTYPE FOR CANVAS RENDERING");
-        }
-      });
-    }
+      context.translate(...this.props.position);
+      context.translate(piece.tx, piece.ty);
+      context.fillStyle = fill;
+      context.strokeStyle = stroke;
+      context.lineWidth = style.strokeWidth ? style.strokeWidth : "black";
+      if (piece.markProps.markType === "circle") {
+        context.beginPath();
+        context.arc(0, 0, piece.markProps.r, 0, 2 * Math.PI);
+        context.stroke();
+        context.fill();
+      } else if (piece.markProps.markType === "rect") {
+        context.fillRect(
+          piece.markProps.x,
+          piece.markProps.y,
+          piece.markProps.width,
+          piece.markProps.height
+        );
+        context.strokeRect(
+          piece.markProps.x,
+          piece.markProps.y,
+          piece.markProps.width,
+          piece.markProps.height
+        );
+      } else if (piece.markProps.markType === "path") {
+        const p = new Path2D(piece.markProps.d);
+        context.stroke(p);
+        context.fill(p);
+      } else {
+        console.error("CURRENTLY UNSUPPORTED MARKTYPE FOR CANVAS RENDERING");
+      }
+    });
   }
 
   componentWillReceiveProps(np) {
@@ -89,7 +85,7 @@ class VisualizationLayer extends React.PureComponent {
     if (
       update === true &&
       (!np.dataVersion ||
-        (np.dataVersion && np.dataVersion !== this.state.dataVersion))
+        np.dataVersion && np.dataVersion !== this.state.dataVersion)
     ) {
       const {
         xScale,
@@ -106,8 +102,8 @@ class VisualizationLayer extends React.PureComponent {
       Object.keys(renderPipeline).forEach(k => {
         const pipe = renderPipeline[k];
         if (
-          (pipe.data && typeof pipe.data === "object") ||
-          (pipe.data && pipe.data.length > 0)
+          pipe.data && typeof pipe.data === "object" ||
+          pipe.data && pipe.data.length > 0
         ) {
           const renderedPipe = pipe.behavior({
             xScale,
@@ -140,18 +136,18 @@ class VisualizationLayer extends React.PureComponent {
       axes,
       axesTickLines,
       frameKey,
-      position = [0, 0]
+      position
     } = props;
-    let { renderedElements } = this.state;
+    const { renderedElements } = this.state;
 
     return (
-      <g transform={"translate(" + position + ")"}>
+      <g transform={`translate(${position})`}>
         <g className="axis axis-tick-lines">{axesTickLines}</g>
         <g
           className="data-visualization"
           key="visualization-clip-path"
           clipPath={
-            matteClip && matte ? "url(#matte-clip" + frameKey + ")" : undefined
+            matteClip && matte ? `url(#matte-clip${frameKey})` : undefined
           }
         >
           {renderedElements}
@@ -160,15 +156,6 @@ class VisualizationLayer extends React.PureComponent {
         <g className="axis axis-labels">{axes}</g>
       </g>
     );
-
-    /*        return <MarkContext
-          position={this.props.adjustedPosition}
-          size={this.props.adjustedSize}
-          xyFrameChildren={true}
-          renderNumber={this.props.renderNumber}
-          canvasContext={this.props.canvasContext}
-        >
-        </MarkContext> */
   }
 }
 


### PR DESCRIPTION
Also:
* responsive frame test
* start to RY up code that should be using defaultProps
* simplify canvas init code since none of it can run with context
* don't lint docs
* start to use safer template strings instead of concatenation as all platforms support them now, even if this project wasn't using Babel