### PR TITLE
Add ESLint config file

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "root": true,
+  "extends": ["netflix-dea"]
+}


### PR DESCRIPTION
`npm run lint` fails because ESLint can't find a config file.