### PR TITLE
Fixing unpkg dist file

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.7.12",
   "description": "The semiotic JavaScript data visualization framework",
   "main": "lib/index.js",
-  "unpkg": "dist/semiotic.js",
+  "unpkg": "dist/semiotic.min.js",
   "files": ["lib", "dist"],
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
unpkg for https://unpkg.com/semiotic@1.7.12 says:

> Cannot find module "dist/semiotic.js" in package semiotic@1.7.12

and that is true ;) just missing the .min.

