### PR TITLE
Add minimal Travis CI Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: node_js
+
+node_js:
+  - "lts/*"
+  - "8"
+
+install:
+  - npm install
+
+script:
+  # - npm run lint  # disabled in current semiotic
+  - npm run test
+
+cache:
+  directories:
+    - "node_modules"


### PR DESCRIPTION
# Context
- A few days ago, all the codepen examples temporarily stopped working due to to new changes in the package
- Adding tests to our CI will make it easier to avoid regressions/builds breaking.

# Future Todos
- Tie travis to @emeeks's account or a project maintainer instead of mine
- Report CI results within the PR using the github integration
- Add build status to `README.md`
- Bring back the linting test when appropriate (just uncomment a line in `.travis.yml`

Fixing up the results of the current test suite will be covered in separate PRs.

Build results: https://travis-ci.org/hydrosquall/semiotic/branches