### PR TITLE
document pixelColumnWidth prop that lets you set the width of a bar mark on an ordinal char

### DIFF
--- a/src/docs/components/OrdinalFrameDocs.js
+++ b/src/docs/components/OrdinalFrameDocs.js
@@ -191,6 +191,7 @@ components.push({
     PropTypes.bool,
     PropTypes.func
   ]),
+  pixelColumnWidth: PropTypes.number,
   hoverAnnotation: PropTypes.bool,
   axis: PropTypes.object,
   backgroundGraphics:  PropTypes.oneOfType([


### PR DESCRIPTION
This PR documents the `pixelColumnWidth` prop that lets you set the width of a bar mark on an ordinal chart

fix #230 