### PR TITLE
switch to running jest directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   "scripts": {
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
-    "test": "node scripts/test.js --env=jsdom",
+    "test": "BABEL_ENV=test NODE_ENV=test PUBLIC_URL='' jest --env=jsdom",
+    "test:watch": "npm run test -- --watch",
+    "test:coverage": "npm run test -- --coverage",
+    "test:old": "node scripts/test.js --env=jsdom",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "prebuild": "babel src/components --out-dir lib --ignore test.js",


### PR DESCRIPTION
Tests were failing to start for me with:

```
$ npm t

> semiotic@1.11.1 test /Users/kylek/code/src/github.com/emeeks/semiotic
> node scripts/test.js --env=jsdom

2018-05-29 08:28 node[11675] (FSEvents.framework) FSEventStreamStart: register_with_server: ERROR: f2d_register_rpc() => (null) (-22)
2018-05-29 08:28 node[11675] (FSEvents.framework) FSEventStreamStart: register_with_server: ERROR: f2d_register_rpc() => (null) (-22)
2018-05-29 08:28 node[11675] (FSEvents.framework) FSEventStreamStart: register_with_server: ERROR: f2d_register_rpc() => (null) (-22)
events.js:183
      throw er; // Unhandled 'error' event
      ^

Error: Error watching file for changes: EMFILE
    at _errnoException (util.js:1022:11)
    at FSEvent.FSWatcher._handle.onchange (fs.js:1351:9)
npm ERR! Test failed.  See above for more details.
```

I noticed that the original scripts here came from ejecting from create-react-app and are way out of date with other dependencies, so I made some separate testing commands:

```
npm test -- runs tests (no watching)
npm run test:watch -- runs tests, watching files for you
npm run test:coverage -- runs coverage reporting with tests
```

I did also leave:

```
npm run test:old
```

as the old version, though it's certainly not working for me on a clean install.