### PR TITLE
ensure flow types get removed

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "rollup": "^0.51.8",
     "rollup-plugin-babel": "^3.0.2",
     "rollup-plugin-commonjs": "^8.2.5",
+    "rollup-plugin-flow": "^1.1.1",
     "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-regenerator": "^0.5.4",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,8 @@ import builtins from "rollup-plugin-node-builtins"
 import replace from "rollup-plugin-replace"
 import regenerator from "rollup-plugin-regenerator"
 
+import flow from 'rollup-plugin-flow';
+
 export default {
   exports: "named",
   input: "src/components/index.js",
@@ -20,6 +22,7 @@ export default {
   },
   external: ["react", "react-dom"],
   plugins: [
+    flow(),
     node({ jsnext: true, preferBuiltins: false }),
     regenerator({ includeRuntime: true, sourceMap: false }),
     builtins(),
@@ -41,7 +44,7 @@ export default {
     babel({
       babelrc: false,
       runtimeHelpers: true,
-      presets: [["es2015", { modules: false }], "react", "stage-0"],
+      presets: ["flow", ["es2015", { modules: false }], "react", "stage-0"],
       plugins: ["external-helpers"]
     })
   ]

--- a/src/components/Annotation.js
+++ b/src/components/Annotation.js
@@ -5,7 +5,7 @@ import AnnotationLabel from "react-annotation/lib/Types/AnnotationLabel"
 type Props = {
   noteData: {
     eventListeners: Object,
-    type: ?function,
+    type: *,
     screenCoordinates: Array<Array<number>>,
     // What is this type supposed to be? It gets used only in a boolean context
     // I mostly assume this is used to indicate the presence of `nx`, `ny`, `dx`, `dy`


### PR DESCRIPTION
I didn't realize that rollup was using a separate config for babel and needed a separate step for removing flow types. I've fixed things up so that `master` can install again. 😅 