### PR TITLE
relegate rollup building to a prepublishOnly step

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "deploy-docs": "sh ./scripts/docs.sh",
     "ci-deploy-docs": "sh ./scripts/docs-ci.sh",
     "gh-pages": "REACT_APP_GH_PAGES_PATH='semiotic' npm run build",
-    "prepublish": "rollup -c && uglifyjs ./dist/semiotic.js -o ./dist/semiotic.min.js && rm ./dist/semiotic.js"
+    "prepublishOnly": "rollup -c && uglifyjs ./dist/semiotic.js -o ./dist/semiotic.min.js && rm ./dist/semiotic.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Ever since npm 4, they've deprecated `prepublish` and opted for `prepublishOnly`. This does mean that building the dist copy will only happen prior to publish (and not on dev install). If you do really want it to rebuild the `dist` copy, we can make this a `prepare` step. Let me know!