### PR TITLE
Fixup rollup config

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,12 +198,6 @@
       "node"
     ]
   },
-  "babel": {
-    "presets": [
-      "flow",
-      "react-app"
-    ]
-  },
   "eslintConfig": {
     "extends": "react-app"
   }

--- a/src/components/Annotation.js
+++ b/src/components/Annotation.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from "react"
+import React from "react"
 import AnnotationLabel from "react-annotation/lib/Types/AnnotationLabel"
 
 type Props = {


### PR DESCRIPTION
Current release's dist copy was failing due to two different versions of a global `React`. One was the default import, `import React from "react"`. The other was the globbed named import `import * as React from "react"`. Because the rollup config is specifying react to be a global, we have to keep the kind of `React` the same.

While I was at it (since I spent time debugging), I got rid of the extra babel config that was in the package.json (when there's also one as `.babelrc`).