### PR TITLE
Show Circle CI Status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Semiotic](semiotic_logo_horizontal.png "semiotic")](https://github.com/emeeks/semiotic/wiki/)
 
+[![Circle CI Status Shield](https://circleci.com/gh/emeeks/semiotic/tree/master.svg?style=shield)](https://circleci.com/gh/emeeks/semiotic/tree/master)
+
 Semiotic is a data visualization framework combining React &amp; D3
 
 [Interactive Documentation](https://emeeks.github.io/semiotic/)

--- a/src/components/NetworkFrame.js
+++ b/src/components/NetworkFrame.js
@@ -602,6 +602,13 @@ class NetworkFrame extends React.Component<Props, State> {
       }
     }
 
+    const title =
+      typeof baseTitle === "object" &&
+      !React.isValidElement(baseTitle) &&
+      baseTitle !== null
+        ? baseTitle
+        : { title: baseTitle, orient: "top" }
+
     const margin = calculateMargin({
       margin: baseMargin,
       title
@@ -654,13 +661,6 @@ class NetworkFrame extends React.Component<Props, State> {
     const nodeRenderModeFn = stringToFn(nodeRenderMode, undefined, true)
     const nodeCanvasRenderFn =
       canvasNodes && stringToFn(canvasNodes, undefined, true)
-
-    const title =
-      typeof baseTitle === "object" &&
-      !React.isValidElement(baseTitle) &&
-      baseTitle !== null
-        ? baseTitle
-        : { title: baseTitle, orient: "top" }
 
     let { projectedNodes, projectedEdges } = this.state
 

--- a/src/components/NetworkFrame.js
+++ b/src/components/NetworkFrame.js
@@ -188,26 +188,20 @@ function determineNodeIcon(baseCustomNodeIcon, networkSettings, size) {
   switch (networkSettings.type) {
     case "sankey":
       return sankeyNodeGenerator
-      break
     case "partition":
       return networkSettings.projection === "radial"
         ? radialRectNodeGenerator(size, center)
         : hierarchicalRectNodeGenerator
-      break
     case "treemap":
       return networkSettings.projection === "radial"
         ? radialRectNodeGenerator(size, center)
         : hierarchicalRectNodeGenerator
-      break
     case "circlepack":
       return circleNodeGenerator
-      break
     case "wordcloud":
       return wordcloudNodeGenerator
-      break
     case "chord":
       return chordNodeGenerator(size)
-      break
   }
 
   return circleNodeGenerator
@@ -219,19 +213,14 @@ function determineEdgeIcon(baseCustomEdgeIcon, networkSettings, size) {
   switch (networkSettings.type) {
     case "partition":
       return () => null
-      break
     case "treemap":
       return () => null
-      break
     case "circlepack":
       return () => null
-      break
     case "wordcloud":
       return () => null
-      break
     case "chord":
       return chordEdgeGenerator(size)
-      break
   }
   return undefined
 }


### PR DESCRIPTION
Show the CI status with a trim little badge. Makes it easy to click to the latest `master` build so you know if the repo is 😡 or 😄:

[![Circle CI Status Shield](https://circleci.com/gh/emeeks/semiotic/tree/master.svg?style=shield)](https://circleci.com/gh/emeeks/semiotic/tree/master)

Since `master` is currently failing via the flow check, I took the liberty of fixing it up.