### PR TITLE
Vendorized settings back

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:coverage": "npm run test -- --coverage",
     "test:old": "node scripts/test.js --env=jsdom",
     "pretest:dist": "npm run dist",
-    "test:dist": "echo 'var self = this; require(\"./dist/semiotic.js\");' | node -",
+    "test:dist": "echo 'write some integration tests with puppeteer please'",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "flow": "flow",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "d3-selection": "^1.1.0",
     "d3-shape": "^1.0.4",
     "d3-voronoi": "^1.0.2",
-    "element-resize-event": "git://github.com/emeeks/element-resize-event.git",
+    "element-resize-event-tabindex": "0.0.1",
     "json2csv": "3.11.5",
     "labella": "1.1.4",
     "object-assign": "4.1.1",
@@ -153,7 +153,7 @@
     "prop-types": "15.6.0",
     "raf": "3.4.0",
     "react-annotation": "1.2.1",
-    "roughjs": "git://github.com/emeeks/rough.git",
+    "roughjs-es5": "0.1.0",
     "semiotic-mark": "0.2.12",
     "svg-path-bounding-box": "1.0.4",
     "whatwg-fetch": "2.0.3"

--- a/src/components/ResponsiveFrame.js
+++ b/src/components/ResponsiveFrame.js
@@ -1,6 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
-import elementResizeEvent from "element-resize-event"
+import elementResizeEvent from "element-resize-event-tabindex"
 
 const createResponsiveFrame = Frame =>
   class ResponsiveFrame extends React.Component {

--- a/src/components/VisualizationLayer.js
+++ b/src/components/VisualizationLayer.js
@@ -2,7 +2,7 @@
 
 import React from "react"
 
-import { RoughCanvas } from "roughjs/lib/canvas"
+import { RoughCanvas } from "roughjs-es5/lib/canvas"
 
 import { chuckCloseCanvasTransform } from "./canvas/basicCanvasEffects"
 


### PR DESCRIPTION
* package.json ref to element-resize-event-tabindex and roughjs-es5
* Update ResponsiveFrame to reference element-resize-event-tabindex
* Update VisualizationLayer to reference roughjs-es5