### PR TITLE
Switch dates comparison to use numeric timestamp

### DIFF
--- a/src/components/svg/lineDrawing.js
+++ b/src/components/svg/lineDrawing.js
@@ -4,7 +4,7 @@ import { sum } from "d3-array"
 
 import { findFirstAccessorValue } from "../data/multiAccessorUtils"
 
-const datesForUnique = d => (d instanceof Date ? d.toString() : d)
+const datesForUnique = d => (d instanceof Date ? d.getTime() : d)
 
 type AreaProjectionTypes = {
   data: Array<Object>,


### PR DESCRIPTION
Reduces componentWillReceiveProps time for complex area charts significantly.