### PR TITLE
Performance improvements for XYFrame

### DIFF
--- a/src/components/XYFrame.js
+++ b/src/components/XYFrame.js
@@ -449,7 +449,8 @@ class XYFrame extends React.Component<XYFrameProps, State> {
       areaDataAccessor,
       yAccessor,
       xAccessor,
-      useAreasAsInteractionLayer
+      useAreasAsInteractionLayer,
+      baseMarkProps
     } = currentProps
     let {
       projectedLines,
@@ -660,7 +661,8 @@ class XYFrame extends React.Component<XYFrameProps, State> {
             {axisLines({
               axisParts,
               orient: d.orient,
-              tickLineGenerator: d.tickLineGenerator
+              tickLineGenerator: d.tickLineGenerator,
+              baseMarkProps
             })}
           </g>
         )

--- a/src/components/XYFrame.js
+++ b/src/components/XYFrame.js
@@ -342,16 +342,16 @@ class XYFrame extends React.Component<XYFrameProps, State> {
       (oldYExtent[1] !== newYExtent[1] && newYExtent[1] !== undefined)
 
     const lineChange =
+      lineData !== newLines ||
       (Array.isArray(lineData) &&
         Array.isArray(newLines) &&
-        !!lineData.find(p => newLines.indexOf(p) === -1)) ||
-      lineData !== newLines
+        !!lineData.find(p => newLines.indexOf(p) === -1))
 
     const areaChange =
+      areaData !== newAreas ||
       (Array.isArray(areaData) &&
         Array.isArray(newAreas) &&
-        !!areaData.find(p => newAreas.indexOf(p) === -1)) ||
-      areaData !== newAreas
+        !!areaData.find(p => newAreas.indexOf(p) === -1))
 
     if (
       (oldDataVersion && oldDataVersion !== newDataVersion) ||

--- a/src/components/XYFrame.js
+++ b/src/components/XYFrame.js
@@ -160,7 +160,8 @@ export type XYFrameProps = {
   projectedLines?: Array<Object>,
   projectedAreas?: Array<Object>,
   projectedPoints?: Array<Object>,
-  renderOrder?: $ReadOnlyArray<"lines" | "points" | "areas">
+  renderOrder?: $ReadOnlyArray<"lines" | "points" | "areas">,
+  useAreasAsInteractionLayer?: boolean,
 }
 
 type State = {
@@ -195,7 +196,8 @@ type State = {
   xyFrameRender: Object,
   canvasDrawing: Array<Object>,
   size: Array<number>,
-  annotatedSettings: Object
+  annotatedSettings: Object,
+  overlay: Array<Object>,
 }
 
 const naturalLanguageLineType = {
@@ -446,7 +448,8 @@ class XYFrame extends React.Component<XYFrameProps, State> {
       lineDataAccessor,
       areaDataAccessor,
       yAccessor,
-      xAccessor
+      xAccessor,
+      useAreasAsInteractionLayer,
     } = currentProps
     let {
       projectedLines,
@@ -828,6 +831,15 @@ class XYFrame extends React.Component<XYFrameProps, State> {
       yExtentSettings.onChange(calculatedYExtent)
     }
 
+    let overlay = undefined
+    if (useAreasAsInteractionLayer && projectedAreas) {
+      overlay = createAreas({ xScale, yScale, data: projectedAreas }).map((m, i) => ({
+        ...m.props,
+        style: {fillOpacity: 0},
+        overlayData: projectedAreas[i] // luckily createAreas is a map fn
+      }))
+    }
+
     this.setState({
       lineData: currentProps.lines,
       pointData: currentProps.points,
@@ -866,7 +878,8 @@ class XYFrame extends React.Component<XYFrameProps, State> {
       areaAnnotations,
       xyFrameRender,
       size,
-      annotatedSettings
+      annotatedSettings,
+      overlay,
     })
   }
 
@@ -1283,7 +1296,8 @@ class XYFrame extends React.Component<XYFrameProps, State> {
       areaAnnotations,
       legendSettings,
       xyFrameRender,
-      annotatedSettings
+      annotatedSettings,
+      overlay,
     } = this.state
 
     let downloadButton
@@ -1366,6 +1380,7 @@ class XYFrame extends React.Component<XYFrameProps, State> {
         useSpans={useSpans}
         canvasRendering={!!(canvasAreas || canvasPoints || canvasLines)}
         renderOrder={renderOrder}
+        overlay={overlay}
       />
     )
   }

--- a/src/components/XYFrame.js
+++ b/src/components/XYFrame.js
@@ -449,7 +449,7 @@ class XYFrame extends React.Component<XYFrameProps, State> {
       areaDataAccessor,
       yAccessor,
       xAccessor,
-      useAreasAsInteractionLayer,
+      useAreasAsInteractionLayer
     } = currentProps
     let {
       projectedLines,
@@ -835,7 +835,7 @@ class XYFrame extends React.Component<XYFrameProps, State> {
     if (useAreasAsInteractionLayer && projectedAreas) {
       overlay = createAreas({ xScale, yScale, data: projectedAreas }).map((m, i) => ({
         ...m.props,
-        style: {fillOpacity: 0},
+        style: { fillOpacity: 0 },
         overlayData: projectedAreas[i] // luckily createAreas is a map fn
       }))
     }
@@ -879,7 +879,7 @@ class XYFrame extends React.Component<XYFrameProps, State> {
       xyFrameRender,
       size,
       annotatedSettings,
-      overlay,
+      overlay
     })
   }
 
@@ -1297,7 +1297,7 @@ class XYFrame extends React.Component<XYFrameProps, State> {
       legendSettings,
       xyFrameRender,
       annotatedSettings,
-      overlay,
+      overlay
     } = this.state
 
     let downloadButton

--- a/src/components/constants/frame_props.js
+++ b/src/components/constants/frame_props.js
@@ -236,7 +236,8 @@ export const xyframeproptypes = {
   customLineMark: PropTypes.func,
   customAreaMark: PropTypes.func,
   lineIDAccessor: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  minimap: PropTypes.object
+  minimap: PropTypes.object,
+  useAreasAsInteractionLayer: PropTypes.bool,
 }
 
 export const ordinalframeproptypes = {

--- a/src/components/constants/frame_props.js
+++ b/src/components/constants/frame_props.js
@@ -237,7 +237,7 @@ export const xyframeproptypes = {
   customAreaMark: PropTypes.func,
   lineIDAccessor: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   minimap: PropTypes.object,
-  useAreasAsInteractionLayer: PropTypes.bool,
+  useAreasAsInteractionLayer: PropTypes.bool
 }
 
 export const ordinalframeproptypes = {

--- a/src/components/data/dataFunctions.js
+++ b/src/components/data/dataFunctions.js
@@ -181,30 +181,25 @@ export const calculateDataExtent = ({
       xAccessor,
       yAccessor
     })
+
     projectedAreas.forEach(d => {
       const baseData = d._baseData
       if (d._xyfCoordinates[0][0][0]) {
         d._xyfCoordinates[0].forEach(multi => {
-          fullDataset = [
-            ...fullDataset,
-            ...multi.map((p, q) =>
-              Object.assign({ parentArea: d }, baseData[q], {
-                [projectedX]: p[0],
-                [projectedY]: p[1]
-              })
-            )
-          ]
-        })
-      } else {
-        fullDataset = [
-          ...fullDataset,
-          ...d._xyfCoordinates.map((p, q) =>
+          multi.map((p, q) =>
             Object.assign({ parentArea: d }, baseData[q], {
               [projectedX]: p[0],
               [projectedY]: p[1]
             })
-          )
-        ]
+          ).forEach(e => fullDataset.push(e))
+        })
+      } else {
+        d._xyfCoordinates.map((p, q) =>
+          Object.assign({ parentArea: d }, baseData[q], {
+            [projectedX]: p[0],
+            [projectedY]: p[1]
+          })
+        ).forEach(e => fullDataset.push(e))
       }
     })
   }

--- a/src/components/svg/lineDrawing.js
+++ b/src/components/svg/lineDrawing.js
@@ -4,7 +4,7 @@ import { sum } from "d3-array"
 
 import { findFirstAccessorValue } from "../data/multiAccessorUtils"
 
-const datesForUnique = d => (d instanceof Date ? d.toString() : d)
+const datesForUnique = d => (d instanceof Date ? d.getTime() : d)
 
 type AreaProjectionTypes = {
   data: Array<Object>,

--- a/src/components/visualizationLayerBehavior/axis.js
+++ b/src/components/visualizationLayerBehavior/axis.js
@@ -2,7 +2,7 @@ import React from "react"
 
 import { Mark } from "semiotic-mark"
 
-const defaultTickLineGenerator = ({ xy, orient, i }) => (
+const defaultTickLineGenerator = ({ xy, orient, i, baseMarkProps }) => (
   <Mark
     key={i}
     markType="path"
@@ -12,6 +12,7 @@ const defaultTickLineGenerator = ({ xy, orient, i }) => (
     simpleInterpolate={true}
     d={`M${xy.x1},${xy.y1}L${xy.x2},${xy.y2}`}
     className={`tick-line tick ${orient}`}
+    {...baseMarkProps}
   />
 )
 
@@ -139,9 +140,10 @@ export const axisLabels = ({ axisParts, tickFormat, rotate = 0 }) => {
 export const axisLines = ({
   axisParts,
   orient,
-  tickLineGenerator = defaultTickLineGenerator
+  tickLineGenerator = defaultTickLineGenerator,
+  baseMarkProps
 }) => {
   return axisParts.map((axisPart, i) =>
-    tickLineGenerator({ xy: axisPart, orient, i })
+    tickLineGenerator({ xy: axisPart, orient, i, baseMarkProps })
   )
 }

--- a/src/components/visualizationLayerBehavior/general.js
+++ b/src/components/visualizationLayerBehavior/general.js
@@ -389,8 +389,10 @@ export function createAreas({
       className = `xyframe-area ${areaClass(d)}`
     }
     let drawD = ""
+    let shouldBeValid = false
     if (d.customMark) {
       drawD = d.customMark
+      shouldBeValid = true
     } else if (d.type === "MultiPolygon") {
       d.coordinates.forEach(coord => {
         coord.forEach(c => {
@@ -411,6 +413,7 @@ export function createAreas({
         yScale,
         bounds: shapeBounds(projectedCoordinates)
       })
+      shouldBeValid = true
     } else {
       drawD = `M${d._xyfCoordinates
         .map(p => `${xScale(p[0])},${yScale(p[1])}`)
@@ -419,7 +422,7 @@ export function createAreas({
 
     const renderKey = renderKeyFn ? renderKeyFn(d, i) : `area-${i}`
 
-    if (React.isValidElement(drawD)) {
+    if (shouldBeValid && React.isValidElement(drawD)) {
       renderedAreas.push(drawD)
     } else if (canvasRender && canvasRender(d, i) === true) {
       const canvasArea = {


### PR DESCRIPTION
A number of performance bumps to support my use case (XYFrame - area, line, and heatmap).

Specifically -
- Use a numeric comparison for dates to avoid `Date->toString()` string instantiation
- Use a mutating array in `calculateDataExtent` instead of O(n^2) concatenating since the interim results are not needed
- Allow change ordering of shortcut `||` comparison in XYFrame componentWillReceiveProps so that if new data is available that can be worked out quickly (ie: do the really quick and easy part of the or first, and only if that fails do the deep comparison)
- Add a status flag `shouldBeValid` so that we only ask React to validate the object if we believe it should work (ie: bypass if we know it won't be React)
- Add a `useAreasAsInteractionLayer` option to XYFrame for heatmapping. The voronoi calculation is somewhat expensive for an area with thousands of elements, and given we already know exactly the areas we want to use for our interaction layer, allow us to use that instead.
- Pass baseMarkProps through XYFrame for the axis marks as well so that animations can be disabled.

For a heatmap like this:

![image](https://user-images.githubusercontent.com/3196528/44960430-81cf6880-aeb4-11e8-8f61-a139ca4468ce.png)

Before: (Approx 200ms render, plus regular animation - of which JS time 170ms)

![image](https://user-images.githubusercontent.com/3196528/44960424-73814c80-aeb4-11e8-9faf-5f94ba9d14fb.png)

After: (Approx 100ms render, no animation - of which JS time 60ms)

![image](https://user-images.githubusercontent.com/3196528/44960512-f060f600-aeb5-11e8-95eb-d084d48e6507.png)

