### PR TITLE
prettify all the js

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ import builtins from "rollup-plugin-node-builtins"
 import replace from "rollup-plugin-replace"
 import regenerator from "rollup-plugin-regenerator"
 
-import flow from 'rollup-plugin-flow';
+import flow from "rollup-plugin-flow"
 
 export default {
   exports: "named",
@@ -17,7 +17,7 @@ export default {
   },
   interop: false,
   globals: {
-    "react": "React",
+    react: "React",
     "react-dom": "ReactDOM"
   },
   external: ["react", "react-dom"],

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -57,14 +57,14 @@ measureFileSizesBeforeBuild(paths.appBuild)
         console.info(chalk.yellow("Compiled with warnings.\n"))
         console.info(warnings.join("\n\n"))
         console.info(
-          `\nSearch for the ${ 
-            chalk.underline(chalk.yellow("keywords")) 
-            } to learn more about each warning.`
+          `\nSearch for the ${chalk.underline(
+            chalk.yellow("keywords")
+          )} to learn more about each warning.`
         )
         console.info(
-          `To ignore, add ${ 
-            chalk.cyan("// eslint-disable-next-line") 
-            } to the line before.\n`
+          `To ignore, add ${chalk.cyan(
+            "// eslint-disable-next-line"
+          )} to the line before.\n`
         )
       } else {
         console.info(chalk.green("Compiled successfully.\n"))

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -90,8 +90,7 @@ choosePort(HOST, DEFAULT_PORT)
       console.info(chalk.cyan("Starting the development server...\n"))
       openBrowser(urls.localUrlForBrowser)
     })
-
-    ;["SIGINT", "SIGTERM"].forEach((sig) => {
+    ;["SIGINT", "SIGTERM"].forEach(sig => {
       process.on(sig, () => {
         devServer.close()
         process.exit()

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,27 +1,26 @@
-'use strict';
+"use strict"
 
 // Do this as the first thing so that any code reading it knows the right env.
-process.env.BABEL_ENV = 'test';
-process.env.NODE_ENV = 'test';
-process.env.PUBLIC_URL = '';
+process.env.BABEL_ENV = "test"
+process.env.NODE_ENV = "test"
+process.env.PUBLIC_URL = ""
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
 // terminate the Node.js process with a non-zero exit code.
-process.on('unhandledRejection', err => {
-  throw err;
-});
+process.on("unhandledRejection", err => {
+  throw err
+})
 
 // Ensure environment variables are read.
-require('../config/env');
+require("../config/env")
 
-const jest = require('jest');
-const argv = process.argv.slice(2);
+const jest = require("jest")
+const argv = process.argv.slice(2)
 
 // Watch unless on CI or in coverage mode
-if (!process.env.CI && argv.indexOf('--coverage') < 0) {
-  argv.push('--watch');
+if (!process.env.CI && argv.indexOf("--coverage") < 0) {
+  argv.push("--watch")
 }
 
-
-jest.run(argv);
+jest.run(argv)

--- a/src/components/Frame.js
+++ b/src/components/Frame.js
@@ -63,14 +63,16 @@ type Props = {
   axes?: Array<AxisType>,
   axesTickLines?: Node,
   disableCanvasInteraction?: boolean,
-  renderOrder: $ReadOnlyArray<| "pieces"
+  renderOrder: $ReadOnlyArray<
+    | "pieces"
     | "summaries"
     | "connectors"
     | "edges"
     | "nodes"
     | "areas"
     | "lines"
-    | "points">
+    | "points"
+  >
 }
 
 type State = {

--- a/src/components/Legend.js
+++ b/src/components/Legend.js
@@ -20,14 +20,19 @@ type LegendGroup = {
 }
 
 type Props = {
-    legendGroups: Array<LegendGroup>,
-    title?: string,
-    width?: number,
-    height?: number,
-    orientation?: string
+  legendGroups: Array<LegendGroup>,
+  title?: string,
+  width?: number,
+  height?: number,
+  orientation?: string
 }
 
-function renderType(item:Object, i:number, type:ItemType, styleFn:Function) {
+function renderType(
+  item: Object,
+  i: number,
+  type: ItemType,
+  styleFn: Function
+) {
   let renderedType
   if (typeof type === "function") {
     renderedType = type(item)
@@ -40,7 +45,7 @@ function renderType(item:Object, i:number, type:ItemType, styleFn:Function) {
 }
 
 class Legend extends React.Component<Props, null> {
-  renderLegendGroup(legendGroup:LegendGroup) {
+  renderLegendGroup(legendGroup: LegendGroup) {
     const { type = "fill", styleFn, items } = legendGroup
     const renderedItems = []
     let itemOffset = 0
@@ -59,7 +64,7 @@ class Legend extends React.Component<Props, null> {
     return renderedItems
   }
 
-  renderLegendGroupHorizontal(legendGroup:LegendGroup) {
+  renderLegendGroupHorizontal(legendGroup: LegendGroup) {
     const { type = "fill", styleFn, items } = legendGroup
     const renderedItems = []
     let itemOffset = 0
@@ -79,7 +84,13 @@ class Legend extends React.Component<Props, null> {
     return { items: renderedItems, offset: itemOffset }
   }
 
-  renderGroup({ legendGroups, width }:{ legendGroups: Array<LegendGroup>, width: number }) {
+  renderGroup({
+    legendGroups,
+    width
+  }: {
+    legendGroups: Array<LegendGroup>,
+    width: number
+  }) {
     let offset = 30
 
     const renderedGroups = []
@@ -126,7 +137,15 @@ class Legend extends React.Component<Props, null> {
     return renderedGroups
   }
 
-  renderHorizontalGroup({ legendGroups, title, height }:{ legendGroups:Array<LegendGroup>, title: string, height: number }) {
+  renderHorizontalGroup({
+    legendGroups,
+    title,
+    height
+  }: {
+    legendGroups: Array<LegendGroup>,
+    title: string,
+    height: number
+  }) {
     let offset = 0
 
     const renderedGroups = []

--- a/src/components/MiniMap.js
+++ b/src/components/MiniMap.js
@@ -7,7 +7,16 @@ import XYFrame from "./XYFrame"
 import PropTypes from "prop-types"
 
 const MiniMap = props => {
-  const { brushStart, brush, brushEnd, xBrushable, yBrushable, yBrushExtent, xBrushExtent, ...rest } = props
+  const {
+    brushStart,
+    brush,
+    brushEnd,
+    xBrushable,
+    yBrushable,
+    yBrushExtent,
+    xBrushExtent,
+    ...rest
+  } = props
   const interactivity = {
     start: brushStart,
     during: brush,

--- a/src/components/ResponsiveFrame.test.js
+++ b/src/components/ResponsiveFrame.test.js
@@ -6,10 +6,10 @@ import ResponsiveXYFrame from "./ResponsiveXYFrame"
 import ResponsiveOrdinalFrame from "./ResponsiveOrdinalFrame"
 
 const ResponsiveFrameComponents = {
-  "ResponsiveXYFrame": ResponsiveXYFrame,
-  "ResponsiveMinimapXYFrame": ResponsiveMinimapXYFrame,
-  "ResponsiveNetworkFrame": ResponsiveNetworkFrame,
-  "ResponsiveOrdinalFrame": ResponsiveOrdinalFrame
+  ResponsiveXYFrame: ResponsiveXYFrame,
+  ResponsiveMinimapXYFrame: ResponsiveMinimapXYFrame,
+  ResponsiveNetworkFrame: ResponsiveNetworkFrame,
+  ResponsiveOrdinalFrame: ResponsiveOrdinalFrame
 }
 
 describe("ResponsiveFrameComponents", () => {

--- a/src/components/SpanOrDiv.js
+++ b/src/components/SpanOrDiv.js
@@ -9,7 +9,7 @@ type Props = {
   span: boolean
 }
 
-export default (props:Props) => {
+export default (props: Props) => {
   const { style, className, children, span } = props
   if (span)
     return (

--- a/src/components/VisualizationLayer.js
+++ b/src/components/VisualizationLayer.js
@@ -30,14 +30,16 @@ type Props = {
   projectedCoordinateNames: Object,
   position: Array<number>,
   disableContext?: boolean,
-  renderOrder: $ReadOnlyArray<| "pieces"
+  renderOrder: $ReadOnlyArray<
+    | "pieces"
     | "summaries"
     | "connectors"
     | "edges"
     | "nodes"
     | "areas"
     | "lines"
-    | "points">
+    | "points"
+  >
 }
 
 type State = {
@@ -290,8 +292,8 @@ class VisualizationLayer extends React.PureComponent<Props, State> {
           baseMarkProps: Object.assign(baseMarkProps, {
             "aria-label":
               (pipe.ariaLabel && pipe.ariaLabel.items) || "dataviz-element",
-            "role": "img",
-            "tabIndex": -1
+            role: "img",
+            tabIndex: -1
           }),
           ...pipe
         })

--- a/src/components/XYFrame.js
+++ b/src/components/XYFrame.js
@@ -203,21 +203,21 @@ type State = {
 }
 
 const naturalLanguageLineType = {
-  "line": { items: "line", chart: "line chart" },
-  "cumulative": { items: "line", chart: "cumulative chart" },
+  line: { items: "line", chart: "line chart" },
+  cumulative: { items: "line", chart: "cumulative chart" },
   "cumulative-reverse": { items: "line", chart: "cumulative chart" },
-  "linepercent": { items: "line", chart: "line chart" },
-  "stackedarea": { items: "stacked area", chart: "stacked area chart" },
+  linepercent: { items: "line", chart: "line chart" },
+  stackedarea: { items: "stacked area", chart: "stacked area chart" },
   "stackedarea-invert": { items: "stacked area", chart: "stacked area chart" },
-  "stackedpercent": { items: "stacked area", chart: "stacked area chart" },
+  stackedpercent: { items: "stacked area", chart: "stacked area chart" },
   "stackedpercent-invert": {
     items: "stacked area",
     chart: "stacked area chart"
   },
-  "bumparea": { items: "ranked area", chart: "ranked area chart" },
+  bumparea: { items: "ranked area", chart: "ranked area chart" },
   "bumparea-invert": { items: "ranked area", chart: "ranked area chart" },
-  "bumpline": { items: "ranked line", chart: "ranked line chart" },
-  "difference": {
+  bumpline: { items: "ranked line", chart: "ranked line chart" },
+  difference: {
     items: "line",
     chart: "difference chart"
   }
@@ -625,7 +625,6 @@ class XYFrame extends React.Component<XYFrameProps, State> {
 
     const existingBaselines = {}
 
-
     if (currentProps.axes) {
       axesTickLines = []
       axes = currentProps.axes.map((d, i) => {
@@ -976,14 +975,21 @@ class XYFrame extends React.Component<XYFrameProps, State> {
           idAccessor
         })
         if (Array.isArray(yCoordinate)) {
-          return [...coords, [xCoordinate, Math.min(...yCoordinate)], [xCoordinate, Math.max(...yCoordinate)]]
-        }
-        else if (Array.isArray(xCoordinate)) {
-          return [...coords, [Math.min(...xCoordinate), yCoordinate], [Math.max(...xCoordinate), yCoordinate]]
-        }
-        else {
+          return [
+            ...coords,
+            [xCoordinate, Math.min(...yCoordinate)],
+            [xCoordinate, Math.max(...yCoordinate)]
+          ]
+        } else if (Array.isArray(xCoordinate)) {
+          return [
+            ...coords,
+            [Math.min(...xCoordinate), yCoordinate],
+            [Math.max(...xCoordinate), yCoordinate]
+          ]
+        } else {
           return [...coords, [xCoordinate, yCoordinate]]
-        }}, [])
+        }
+      }, [])
     }
 
     const customSVG =
@@ -1129,8 +1135,14 @@ class XYFrame extends React.Component<XYFrameProps, State> {
       return null
     }
 
-    const xCoord =  d[projectedXMiddle] || d[projectedX] || findFirstAccessorValue(xAccessor, d)
-    const yCoord =  d[projectedYMiddle] || d[projectedY] || findFirstAccessorValue(yAccessor, d)
+    const xCoord =
+      d[projectedXMiddle] ||
+      d[projectedX] ||
+      findFirstAccessorValue(xAccessor, d)
+    const yCoord =
+      d[projectedYMiddle] ||
+      d[projectedY] ||
+      findFirstAccessorValue(yAccessor, d)
 
     const xString = xCoord && xCoord.toString ? xCoord.toString() : xCoord
     const yString = yCoord && yCoord.toString ? yCoord.toString() : yCoord

--- a/src/docs/Home.js
+++ b/src/docs/Home.js
@@ -3,7 +3,8 @@ import { PrismCode } from "react-prism"
 import Button from "material-ui/Button"
 import { Link } from "react-router-dom"
 
-const Home = ({ match }) => { // eslint-disable-line no-unused-vars
+const Home = ({ match }) => {
+  // eslint-disable-line no-unused-vars
   // const documentation = <Documentation
   //   selected={match && match.params.component}
   // />
@@ -62,8 +63,8 @@ const Home = ({ match }) => { // eslint-disable-line no-unused-vars
             <span style={{ fontWeight: 900 }}>
               Semiotic is a data visualization framework for React.
             </span>{" "}
-            It provides three types of frames (<Link to="xyframe">XYFrame</Link>,{" "}
-            <Link to="orframe">OrdinalFrame</Link>,{" "}
+            It provides three types of frames (<Link to="xyframe">XYFrame</Link>
+            , <Link to="orframe">OrdinalFrame</Link>,{" "}
             <Link to="networkframe">NetworkFrame</Link>) which allow you to
             deploy a wide variety of charts that share the same rules for how to
             display information. By adjusting the settings of a frame, you can

--- a/src/docs/Introduction.js
+++ b/src/docs/Introduction.js
@@ -1,15 +1,15 @@
-import React from 'react'
-import { wrappedExamples } from './example_settings/example_list'
-import { Link } from 'react-router-dom'
+import React from "react"
+import { wrappedExamples } from "./example_settings/example_list"
+import { Link } from "react-router-dom"
 
 const onlyThreeWrappedExamples = wrappedExamples
   .sort(() => Math.random() - Math.random())
   .filter((d, i) => i < 3)
 
-const intro = 
-  (<div>
+const intro = (
+  <div>
     {onlyThreeWrappedExamples}
-    <div style={{ textAlign: 'center' }}>
+    <div style={{ textAlign: "center" }}>
       <Link to="examples">More Examples</Link>
     </div>
     <h2>Introduction</h2>
@@ -30,9 +30,9 @@ const intro =
       able to dig deeper into visualizations to uncover non-obvious insights.
       Semiotic was designed to enable designers and stakeholders to test a
       variety of visualizations, while still providing control over
-      interactivity and presentation of the data.{' '}
+      interactivity and presentation of the data.{" "}
     </p>
-    <div style={{ textAlign: 'center' }}>
+    <div style={{ textAlign: "center" }}>
       <img
         alt="Data visualization is created in the DOM using a series of layers."
         width="400px"
@@ -47,7 +47,7 @@ const intro =
       using the same mental model for interaction elements, labels or other
       related but distinct components.
     </p>
-  </div>)
-
+  </div>
+)
 
 export default intro


### PR DESCRIPTION
While trying to investigate how/why docs (and the diamond data set in particular) are ending up in the rollup UMD build, I was accidentally changing files with prettier. Went ahead and ran `prettier` on (most of) the js files.