### PR TITLE
Update d3-shape to version ^ 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "d3-sankey-circular": "0.25.0",
     "d3-scale": "^1.0.3",
     "d3-selection": "^1.1.0",
-    "d3-shape": "^1.0.4",
+    "d3-shape": "^1.2.0",
     "json2csv": "3.11.5",
     "labella": "1.1.4",
     "memoize-one": "4.0.0",


### PR DESCRIPTION
The d3-sankey-circular module requires d3-shape@^1.2.0, which exports different primitives. But because semiotic requires version 1.0.4 when d3-sankey-circular tries to access the necessary primitives not present on 1.0.4 it crashes the client.
I didn't see any issue after update from 1.0.4 to 1.2.0.
I used the npm version 6.4.1 to reproduce this issue. This may not be an issue when using yarn.