### PR TITLE
Include prop points on the InteractionLayer to be send as an argument to custom event functions

### DIFF
--- a/src/components/InteractionLayer.js
+++ b/src/components/InteractionLayer.js
@@ -145,12 +145,17 @@ class InteractionLayer extends React.Component<Props, State> {
   canvasMap: Map<string, number> = new Map()
 
   changeVoronoi = (d?: Object, customHoverTypes?: CustomHoverType) => {
+    const {
+      customHoverBehavior,
+      voronoiHover,
+      points
+    } = this.props
     //Until semiotic 2
-    const dataObject = d && d.data ? { ...d.data, ...d } : d
-    if (this.props.customHoverBehavior)
-      this.props.customHoverBehavior(dataObject)
+    const dataObject = d && d.data ? { ...d.data, ...d, points } : { ...d, points }
+    if (customHoverBehavior)
+      customHoverBehavior(dataObject)
 
-    if (!d) this.props.voronoiHover(null)
+    if (!d) voronoiHover(null)
     else if (customHoverTypes === true) {
       const vorD = Object.assign({}, dataObject)
       vorD.type = vorD.type === "column-hover" ? "column-hover" : "frame-hover"
@@ -167,7 +172,7 @@ class InteractionLayer extends React.Component<Props, State> {
         })
         .filter(d => d)
 
-      this.props.voronoiHover(mappedHoverTypes)
+      voronoiHover(mappedHoverTypes)
     }
   }
 
@@ -381,7 +386,6 @@ class InteractionLayer extends React.Component<Props, State> {
       customDoubleClickBehavior,
       hoverAnnotation
     } = props
-
     const whichPoints = {
       top: projectedYTop,
       bottom: projectedYBottom
@@ -482,7 +486,6 @@ class InteractionLayer extends React.Component<Props, State> {
       const renderedOverlay: Array<Node> = overlay.map(
         (overlayRegion: Object, i: number) => {
           const { overlayData, ...rest } = overlayRegion
-
           if (React.isValidElement(overlayRegion.renderElement)) {
             return React.cloneElement(overlayRegion.renderElement, {
               key: `overlay-${i}`,

--- a/src/components/InteractionLayer.js
+++ b/src/components/InteractionLayer.js
@@ -144,14 +144,18 @@ class InteractionLayer extends React.Component<Props, State> {
 
   canvasMap: Map<string, number> = new Map()
 
+  constructDataObject = (d?: Object) => {
+    const { points } = this.props
+    return d && d.data ? { points, ...d.data, ...d } : { points, ...d }
+  }
+
   changeVoronoi = (d?: Object, customHoverTypes?: CustomHoverType) => {
     const {
       customHoverBehavior,
-      voronoiHover,
-      points
+      voronoiHover
     } = this.props
     //Until semiotic 2
-    const dataObject = d && d.data ? { ...d.data, ...d, points } : { ...d, points }
+    const dataObject = this.constructDataObject(d)
     if (customHoverBehavior)
       customHoverBehavior(dataObject)
 
@@ -178,14 +182,14 @@ class InteractionLayer extends React.Component<Props, State> {
 
   clickVoronoi = (d: Object) => {
     //Until semiotic 2
-    const dataObject = d.data ? { ...d.data, ...d } : d
+    const dataObject = this.constructDataObject(d)
 
     if (this.props.customClickBehavior)
       this.props.customClickBehavior(dataObject)
   }
   doubleclickVoronoi = (d: Object) => {
     //Until semiotic 2
-    const dataObject = d.data ? { ...d.data, ...d } : d
+    const dataObject = this.constructDataObject(d)
 
     if (this.props.customDoubleClickBehavior)
       this.props.customDoubleClickBehavior(dataObject)
@@ -672,6 +676,7 @@ class InteractionLayer extends React.Component<Props, State> {
       canvasRendering,
       disableCanvasInteraction
     } = this.props
+
     const { overlayRegions } = this.state
     let { enabled } = this.props
 

--- a/src/components/InteractionLayer.js
+++ b/src/components/InteractionLayer.js
@@ -159,7 +159,7 @@ class InteractionLayer extends React.Component<Props, State> {
     else if (customHoverTypes === true) {
       const vorD = Object.assign({}, dataObject)
       vorD.type = vorD.type === "column-hover" ? "column-hover" : "frame-hover"
-      this.props.voronoiHover(vorD)
+      voronoiHover(vorD)
     } else if (customHoverTypes) {
       const arrayWrappedHoverTypes = Array.isArray(customHoverTypes)
         ? customHoverTypes

--- a/src/components/constants/frame_props.js
+++ b/src/components/constants/frame_props.js
@@ -315,7 +315,15 @@ export const ordinalframeproptypes = {
   summaryHoverAnnotation: sharedframeproptypes.hoverAnnotation,
   axis: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   ordinalAlign: PropTypes.string,
-  multiAxis: PropTypes.bool
+  multiAxis: PropTypes.bool,
+  pieceClass: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func
+  ]),
+  summaryClass: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func
+  ])
 }
 
 export const networkframeproptypes = {


### PR DESCRIPTION
Change: include all points when calling the custom event functions. Useful if we want to show all the summary values (e.g. in boxplots) in a single hover. 

Current solution:
When deriving dataObject on the InteractionLayer component ([example](src/components/InteractionLayer.js)), this change will first add `points` (which is simply the prop of the component), merged by whatever key value pairs from the individual voronoiDataset or overlayData. In case user's data has the same key, this change won't break anything as the original `points` value will be overiden. 

Better/ Long term solution:
Ideally, user's data should be wrapped by a higher level key to avoid key collision with `points`, but that will be a breaking change. Maybe we can do so on the next major release?